### PR TITLE
feat: handle `#no_sync` tag out of sync to twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - 安装包 ```pip install -r requirements.txt```
 - 拷贝一份 `config.sample.py` 到同目录并更名为 `config.py`
 - 修改 `config.py` 中有关 Twitter 和 Mastodon 的参数，之后 `python mtSync.py` 即可
+- 自 commit [9399c2]()(https://github.com/XiaoMouz/Mastodon-to-Twitter-Sync/commit/09399c2255c497b9bfa61beaba481fc21a6b56d8) 之后加入了对 tag `#no_sync` 的判断，在嘟文结尾添加 `#no_sync` 标签将不会同步至推特
 
 ## Linux 后台常驻
 

--- a/mtSync.py
+++ b/mtSync.py
@@ -304,6 +304,12 @@ def sync_main(toot_id):
         skip_toot = False # 重置跳过嘟文标记
         return 0
 
+    # 检查嘟文结尾是否以 “#no_sync” tag 结尾
+    if toot_text.endswith('#no_sync'):
+        tprint(colored('[Check] 嘟文结尾包含不同步标签 #no_sync ，跳过...','green'))
+        save_synced_toots(toot_id)
+        return 0
+
     # 清空媒体缓存文件夹
     if os.path.exists('./media/'):
         shutil.rmtree('./media/',ignore_errors=True)


### PR DESCRIPTION
加入了对 `#no_sync` tag 判断，当嘟文以 `#no_sync` 结尾时将不会同步至推特